### PR TITLE
PR - Write to JSON database only if new rds found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ database/
 metafile/
 *.log
 local.raindrop-todoist-syncer.plist
-.env.backup

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ database/
 metafile/
 *.log
 local.raindrop-todoist-syncer.plist
+.env.backup

--- a/main.py
+++ b/main.py
@@ -29,7 +29,6 @@ def main():
     for task in tasks_to_create:
         task_creator = TodoistTaskCreator(task)
         task_creator.create_task()
-            
 
 def run():
     """

--- a/main.py
+++ b/main.py
@@ -22,8 +22,6 @@ def main():
     raindrop_client = RaindropClient()
     raindrop_oauth = RaindropOauthHandler()
     if raindrop_client.stale_token():
-        logger.warning("Oauth token is stale.")
-        logger.info("Attempting to refresh token.")
         raindrop_oauth.refresh_token_process_runner()    
     all_raindrops = raindrop_client.get_all_raindrops()
     logger.info(f"Collected {len(all_raindrops)} total bookmarks.")

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import time
 import traceback
 
 from loguru import logger
-from raindrop import RaindropClient, RaindropOauthHandler, RaindropsProcessor
+from raindrop import DatabaseManager, RaindropClient, RaindropOauthHandler, RaindropsProcessor
 from todoist import TodoistTaskCreator
 
 from logging_config import configure_logging
@@ -21,6 +21,8 @@ def main():
     """
     raindrop_client = RaindropClient()
     raindrop_oauth = RaindropOauthHandler()
+    dbm = DatabaseManager()
+    
     if raindrop_client.stale_token():
         raindrop_oauth.refresh_token_process_runner()    
     all_raindrops = raindrop_client.get_all_raindrops()
@@ -29,7 +31,8 @@ def main():
     for task in tasks_to_create:
         task_creator = TodoistTaskCreator(task)
         task_creator.create_task()
-
+        dbm.update_database([task])
+        
 def run():
     """
     Function that runs the main function and handles exceptions. Asks the user for:

--- a/main.py
+++ b/main.py
@@ -24,15 +24,12 @@ def main():
     if raindrop_client.stale_token():
         raindrop_oauth.refresh_token_process_runner()    
     all_raindrops = raindrop_client.get_all_raindrops()
-    logger.info(f"Collected {len(all_raindrops)} total bookmarks.")
     raindrops_processor = RaindropsProcessor(all_raindrops)
     tasks_to_create = raindrops_processor.newly_favourited_raindrops_extractor()
-    logger.info(f"Found {len(tasks_to_create)} tasks to create.")
     for task in tasks_to_create:
         task_creator = TodoistTaskCreator(task)
         task_creator.create_task()
-        logger.info(f"Created task: {task.title}")
-    
+            
 
 def run():
     """

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ def main():
         task_creator = TodoistTaskCreator(task)
         task_creator.create_task()
         logger.info(f"Created task: {task.title}")
-
+    
 
 def run():
     """

--- a/raindrop.py
+++ b/raindrop.py
@@ -127,7 +127,7 @@ class RaindropsProcessor:
         rd_objects = self._convert_to_rd_objects(untracked_favs)
         # TODO: This function updates the db - BEFORE the todoist tasks are successfully created.
         # TODO: Keep for now, or the code will not function!! 
-        self._update_previously_favourited(rd_objects)
+        # self._update_previously_favourited(rd_objects)
         return rd_objects
     
     def _extract_all_fav_rds(self) -> List[Dict]:

--- a/raindrop.py
+++ b/raindrop.py
@@ -399,9 +399,11 @@ class RaindropClient:
         """
         try:
             self._core_api_call(page=0)
+            logger.info("Oauth token is valid.")
             return False
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 401:
+                logger.warning("Oauth token is stale.")
                 return True
             else:
                 raise
@@ -774,6 +776,7 @@ class RaindropOauthHandler:
         True    
             Code should raise an error if the entire operation doesn't complete.
         """
+        logger.info("Attempting to refresh token.")
         if not os.getenv("RAINDROP_REFRESH_TOKEN"):
             raise MissingRefreshTokenError("No refresh token in .env. Refresh aborted")
         else:

--- a/raindrop.py
+++ b/raindrop.py
@@ -382,17 +382,20 @@ class RaindropClient:
         
     def stale_token(self) -> bool:
         """
-        Checks the current Oauth token is valid by calling the Raindrop API.
+        Checks the current Oauth2 token is valid by calling the Raindrop API.
         
-        If the initial call passes - the token is valid.  Otherwise, core API call 
-        raises for status.  Valid token catches this error, extracts the 
-        response from the error object and checks for a 401 status code.  401 returns 
-        false - meaning the API has rejected the token and it needs to be refreshed.
+        If the API call succeeds - the token is valid and `stale_token` returns False.
+        If the call fails `_core_api_call` raises an error. `stale token` catches the 
+        error and looks for a 401 status_code. A 401 error indicates the token is stale 
+        and `stale_token` returns True.
         
-        Any other errors are re-raised for higher level handling.
-        
-        Returns:
-            Bool        : True if the token is valid, false if the token is invalid.
+        Any other errors are re-raised for higher level error handling. 
+         
+        Returns
+        -------
+        bool
+            False if the token is valid (i.e. `stale_token` is False, the token is not 
+            stale), True if the token is invalid (it's true the token is stale).
         """
         try:
             self._core_api_call(page=0)

--- a/raindrop.py
+++ b/raindrop.py
@@ -128,6 +128,7 @@ class RaindropsProcessor:
         # TODO: This function updates the db - BEFORE the todoist tasks are successfully created.
         # TODO: Keep for now, or the code will not function!! 
         # self._update_previously_favourited(rd_objects)
+        logger.info(f"Found {len(rd_objects)} tasks to create.")
         return rd_objects
     
     def _extract_all_fav_rds(self) -> List[Dict]:
@@ -453,6 +454,7 @@ class RaindropClient:
                 logger.debug(f"Page({page}) equals target pages({target_pages})")
                 break
         self._cumulative_rds_validator(cumulative_rds, current_rds, benchmark_count)
+        logger.info(f"Collected {len(cumulative_rds)} total bookmarks.")
         return cumulative_rds
 
     def _core_api_call(self, page: int) -> Response:

--- a/raindrop.py
+++ b/raindrop.py
@@ -125,9 +125,6 @@ class RaindropsProcessor:
         tracked_favs = self._fetch_tracked_favs()
         untracked_favs = self._extract_untracked_favs(all_favs, tracked_favs)
         rd_objects = self._convert_to_rd_objects(untracked_favs)
-        # TODO: This function updates the db - BEFORE the todoist tasks are successfully created.
-        # TODO: Keep for now, or the code will not function!! 
-        # self._update_previously_favourited(rd_objects)
         logger.info(f"Found {len(rd_objects)} tasks to create.")
         return rd_objects
     
@@ -194,31 +191,6 @@ class RaindropsProcessor:
             rd_objects.append(Raindrop(raindrop_json))
         logger.info(f"{len(rd_objects)} Raindrop object(s) created.")
         return rd_objects
-
-    def _update_previously_favourited(
-        self, raindrop_objects_for_todoist: List[Raindrop]
-    ) -> bool:
-        """
-        Update the list of previously favorited Raindrop objects.
-
-        Parameters
-        ----------
-        raindrop_objects_for_todoist : List[Raindrop]
-            List of Raindrop objects that have been favorited and are set to be sent to
-            Todoist.
-
-        Returns
-        -------
-        bool
-            Returns True after updating the list of previously favorited Raindrop
-            objects.
-        """
-        # TODO - this is the functionality that needs to be moved latter in the process
-        # flow.
-        db_manager = DatabaseManager()
-        db_manager.update_database(raindrop_objects_for_todoist)
-        logger.info(f"Updated database with {len(raindrop_objects_for_todoist)} new favs.")
-        return True
 
 
 class DatabaseManager:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ asttokens==2.2.1
 attrs==22.2.0
 backcall==0.2.0
 black==23.3.0
-certifi==2023.5.7
+certifi>=2023.7.22
 charset-normalizer==3.1.0
 click==8.1.3
 coverage==7.2.7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,10 @@ from unittest.mock import Mock
 import pytest
 from requests import HTTPError
 
+from raindrop import Raindrop
+
+
+# ------------------------------- mock_requests_get-------------------------------------
 """
 response_one and response_two created using _dummy_collections/dummy_twenty_six in
 raindrop.
@@ -52,7 +56,30 @@ def mock_requests_get_no_status(monkeypatch):
 
     monkeypatch.setattr("requests.get", _mocked_requests_get_no_status)
 
+
+# ------------------------------- mock_db ----------------------------------------------
+
 @pytest.fixture
 def mock_db():
     with open("tests/mock_data/mock_db.json", "r") as f:
         return json.load(f)
+
+# --------------------------- raindrop object ------------------------------------------
+
+@pytest.fixture
+def rd_extracted_single_raindrop_dict():
+    """
+    Returns a dictionary representation of a single raindrop. 
+    In actual usage, this structure is typically extracted from a list of 
+    raindrops that have been processed with json.load. For testing purposes, 
+    this fixture loads the content of a single raindrop saved as JSON from a file.
+    """
+    with open('tests/mock_data/rd_api_single_rd.json', "r") as f:
+        content = json.load(f)
+    return content
+
+
+@pytest.fixture
+def raindrop_object(rd_extracted_single_raindrop_dict):
+   return Raindrop(rd_extracted_single_raindrop_dict)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,3 +51,8 @@ def mock_requests_get_no_status(monkeypatch):
         return mock_response
 
     monkeypatch.setattr("requests.get", _mocked_requests_get_no_status)
+
+@pytest.fixture
+def mock_db():
+    with open("tests/mock_data/mock_db.json", "r") as f:
+        return json.load(f)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,26 @@ def mock_requests_get_no_status(monkeypatch):
 # ------------------------------- mock_db ----------------------------------------------
 
 @pytest.fixture
-def mock_db():
+def mock_db_contents() -> dict:
+    """Returns content of a valid JSON database imported as a python dictionary.
+    
+    The dictionary contains one tracked Raindrop object - the processed version of a 
+    raindrop extracted from a Raindrop.io response.
+    
+    The dictionary contains: 
+    
+    k: "Processed Raindrops" v: [<list of one Raindrop>]. 
+    
+    The Raindrop contains six k, v pairs including:
+    
+    k: "title", v: "Hacker News", 
+    k:"id", v: "28161680"
+    k: "link", v: "https://news.ycombinator.com/news"
+        
+    Returns
+    -------
+    A python dictionary of a valid dictionary containing one tracked raindrop.
+    """
     with open("tests/mock_data/mock_db.json", "r") as f:
         return json.load(f)
 

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -233,17 +233,23 @@ class TestMainValid:
     --------
     What does `main.main` do and how is mocking handled?
 
-    1)  `main.main` confirms the Oauth token is not stale by making an API call using
+    1)  It confirms the Oauth token is not stale by making an API call using
         data in the .env file.
 
-    - patched to return Oauth token is valid
+    See: `test_stale_token_requests_patch` (`test_stale_token_patch` is an alternative)
+    
+    2)  It fetches all raindrops from the raindrops api.
 
-    2) Fetches all raindrops from the raindrops api.
-
-    #TODO:
-    3) Extracts newly favourited raindrops.
-    4) Compares them with the database and extracts 'new' favourites.
-    5) Writes the new favourites to todoist.
+    See: `test_get_all_rds` 
+    
+    3)  It extracts newly favourited raindrops. And it compares them with the database 
+        and extracts 'new' favourites.
+    
+    See: `test_newly_favourited_rd_extractor`
+    
+    4) Writes the new favourites to todoist.
+    
+    See: 
     """
 
     def test_stale_token_patch(self):

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -240,8 +240,9 @@ def mock_database_env(self, monkeypatch, mocked_db_data):
 
 class TestMainValid:
     """
-    Full integration tests with the minimum amount of mocking. Series of tests 
-    validating steps on the happy path.
+    Full happy path integration test with the minimum amount of mocking.
+    
+    Includes individual tests for each mock used for traceability and clarity. 
     
     DETAILS
     --------
@@ -250,29 +251,59 @@ class TestMainValid:
     1)  `main.main` confirms the Oauth token is not stale by making an API call using 
         data in the .env file.
     
-    - mocks the api response with --page one-- of our mock result
-           
+    - patched to return Oauth token is valid 
     
     2) Fetches all raindrops from the raindrops api.
     
-    - mock
-    
+    #TODO:
     3) Extracts newly favourited raindrops.
     4) Compares them with the database and extracts 'new' favourites.
     5) Writes the new favourites to todoist.
+    """
+    def test_stale_token_patch(self):
+        """Patches stale_token to directly return False.
+        
+        We use `mock_requests_get` in the full int test to include the testing of the
+        `stale_token` functionality.
+        """
+        rc = RaindropClient()
+        with patch('raindrop.RaindropClient.stale_token', return_value=7): 
+            stale_token = rc.stale_token()
+        assert stale_token == 7
+    
+    def test_stale_token_requests_patch(self, mock_requests_get):
+        """Uses `mock_requests_get` to monkeypatch `stale_token` uses the p1 of the
+        dummy data returned by `mock_requests_get`.  
+        
+        `stale_token` only requires the get request not to error - it doesn't even check
+        status_code - but `mock_requests_get` does return valid status_codes if req'd.
+        """    
+        rc = RaindropClient()
+        stale_token = rc.stale_token()
+        assert stale_token == False
+        
+    def test_get_all_rds(self, mock_requests_get):
+        """Uses `mock_requests_get` to monkeypatch `requests.get`.
+        
+        Only the `.get` itself is mocked. Two valid pages of API response are returned
+        and validated.  `output` is list of 26 raindrops.
+        """
+        rc = RaindropClient()
+        output = rc.get_all_raindrops()
+        assert len(output) == 26
+        assert type(output) == list
+        assert output[0]['title'] == "Hacker News"
+    
+    # @pytest.mark.skip(message="Not finished yet")
+    def test_happy_path(self, mock_requests_get):
+        """
+        #TODO: in progress
+        Currently illustrates `mock_requests_get` successfully monkeypatching
+        `requests.get` in two seperate function calls.
+        """
+        rc = RaindropClient()
+        stale_token = rc.stale_token()
+        output = rc.get_all_raindrops()
+        assert stale_token == False
+        assert len(output) == 26
    
-    
-     """
-    def test_valid_return(self):
-        # Arrange
-        my_var = 2
-
-        
-        # Act
-        ##actual = main()
-        
-        # Assert
-        assert my_var == 1
-        
-    
-    

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -342,8 +342,15 @@ class TestMainValid:
                 }
                 )
             ) as mock_init:
-        
+
+            # Uses RaindropClient() to extract data from the mock API files rather than 
+            # just loading the data directly because:
+            #   a) use the consolidated two pages of API response provided by 
+            #      `mock_requests_get`
+            #   b) ensures exact formatting correct e.g. dict that starts with 
+            #      "Raindrops processed" vs. just the list of dicts etc.
             rc = RaindropClient()
+            
             # Get mock API response of 26 raindrops / 3 favourites
             output = rc.get_all_raindrops()
             assert len(output) == 26

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -1,11 +1,21 @@
+from datetime import datetime
 import json
-from unittest.mock import patch, MagicMock
+import os
+import shutil
+import tempfile
+from typing import Any
+from unittest.mock import patch, Mock
 
 import pytest
+from requests import Response
 
 from main import main
-from raindrop import RaindropClient, RaindropsProcessor
+from raindrop import DatabaseManager, RaindropClient, RaindropsProcessor
 from todoist import TodoistTaskCreator
+
+from tests.conftest import mock_requests_get
+# This returns a valid response object
+
 
 
 @pytest.fixture
@@ -39,12 +49,15 @@ def mock_raindrops_processor(monkeypatch):
 def mock_todoist_creator(monkeypatch):
     def mock_create_task(self, task):
         pass
+    # monkeypatch.setattr(TodoistTaskCreator, "create_task", mock_create_task)
 
-    monkeypatch.setattr(TodoistTaskCreator, "create_task", mock_create_task)
 
-
-class TestMain:
-
+class TestStaleTokenFunctionality:
+    """
+    Class to focus on testing the stale token functionality. Almost all of the remainder
+    of the main function is mocked.
+    """
+    
     def test_working_test(self):
         assert 1 == 1
 
@@ -97,3 +110,182 @@ class TestMain:
         ) as mock_valid_token:
             main()
             mock_refresh_token_runner.assert_not_called()
+
+
+class TestMainValidReturns:
+    """
+    Full integration tests with the minimum amount of mocking. Series of tests 
+    validating steps on the happy path.
+    
+    - Uses real.env and assumes a non-stale token
+        - mocks the api response & the database used
+           - api finds one new raindrop
+        - rds processed for real
+        - `tasks_to_create` created for real
+    
+    - Writes to mock database 
+     """
+        
+    def mock_db_data(self) -> dict[str, any]:
+        """Creates the contents of a database file. 
+        
+        Can be used in memory (as if read from the file) or written to a file and 
+        then read.
+        
+        Source of the data is an extracted API response using a set of real 
+        raindrops created for testing purposes (e.g. BBC News etc).
+        
+        Two items are removed, allowing the same test set to be used to introduce
+        new, untracked raindrops.
+        
+        Returns
+        -------
+        mock_db_data: dict[str, any]
+            A dictionary containing one item, the key "Processed Raindrops" and the
+            value a list of raindrop dictionaries.
+        
+        See Also
+        --------
+        The return value can be used with `create_mock_db_files` to create a tempfile
+        db and metafile data for most realistic use.
+        """
+        mock_db_data = {
+            "Processed Raindrops": [
+                ]
+        }
+        with open("tests/mock_data/rd_api_response_one.json") as f:
+            full_api_response = json.load(f)
+        mock_db_content = full_api_response["items"][:-2]
+        mock_db_data["Processed Raindrops"] = mock_db_content
+        return mock_db_data
+    
+    def create_mock_db_files(self, directory: str, filename: str, content: dict[str, list]) -> None:
+        """Creates a mock_db file and accompanying metafile.
+        
+        Parameters
+        ----------
+        directory: str
+            The path to the directory to save the mock_db file.
+        
+        filename: str
+            The name for the file e.g. the db file and metafile (which must be in a 
+            particular format).
+        
+        content: dict[str, list]
+            The content of the database. To be valid this should be in the format of
+            one k,v pair with a key of "Processed Raindrops" and the saved raindrop 
+            content as a list of dictionaries.
+        
+        Note
+        ----
+        This method could be used to create any file - but for ease of future me's
+        understanding, I've described it's specific use in `mock_database_env`.
+        """
+        
+        with open(os.path.join(directory, filename), 'w') as file:
+            file.write(content)
+            #! CHAT GPT says this will error a dict
+            #! prob getting this from my type annotations - which may be wrong! 
+            # json.dump(content, file)
+        return None
+
+    @pytest.fixture
+    def mock_database_env(self, monkeypatch, mocked_db_data):
+        """A fixture to mock database/metafile attribes in a DatabaseManager object.
+        
+        For dumb future me: pass this fixture as an argument to any test and 
+        all DatabaseManager calls will be mocked to temp files. 
+        
+        The fixture creates temp directories for the db_file and meta_file. (The 
+        programme uses the meta_file to track the latest version of the db json).
+        
+        It uses `mock_db_data` to create the db content then calls 
+        `create_mock_db_files` to write that db content to the files - with the
+        expected file formatting and metadata content.
+        
+        `monkeypatch.setattr` uses pytest's monkeypatch to mock the DatabaseManager
+        attributes. 
+        
+        Yield is used to keep the method open, pending the required teardown at end
+        of test.
+        
+        Teardown is performed by the shutil commands. (see notes below).
+            
+        
+        Parameters
+        ----------
+        monkeypatch
+            pytest generator that does some (as yet not understood) magic stuff.
+        
+        mocked_db_data: dict[str, list]
+            Mock db data of the type created by `mock_db_data` 
+               
+        Notes
+        -----
+        This fixture is better written as: 
+            `with tempfile.TemporaryDirectory() as db_dir...`
+        I used setattr for consistency across tests (see `mock_requests_get`). As part 
+        of an effort to limit myself to a smaller set of testing tools and learn them
+        properly first. (Rather than every test being so different that "Dec-23 you" 
+        found far too little knowledge consolidating.
+        """
+        db_dir = tempfile.mkdtemp()
+        meta_dir = tempfile.mkdtemp()
+        
+        now = datetime.now()
+        now_formatted = now.strftime("%Y%m%d_%H%M")
+        
+        db_file_name = f"001_processed_raindrops_{now_formatted}.json"
+        meta_file_content = f"{meta_dir}/{db_file_name}.json"
+        # Metafile content format:
+        #   database/2391_processed_raindrops_20231231_0729.json
+        
+        self.create_mock_db_files(db_dir, db_file_name, mocked_db_data)
+        self.create_mock_db_files(meta_dir, 'metafile.txt', meta_file_content)
+
+        monkeypatch.setattr(DatabaseManager, 'database_directory', db_dir)
+        monkeypatch.setattr(DatabaseManager, 'metafile_directory', meta_dir)
+        monkeypatch.setattr(DatabaseManager, 'metafile_path', os.path.join(meta_dir, 'metafile.txt'))
+         
+        yield
+        
+        shutil.rmtree(db_dir)
+        shutil.rmtree(meta_dir)
+        
+        #! NEXT - re-read this and check through, then run some bit by bit tests 
+        #! below.
+         
+    # @patch('todoist.TodoistTaskCreator')
+    #def test_valid_return(self, mock_requests_get):
+    def test_valid_return(self):
+        """
+        - Uses real.env and assumes a non-stale token
+        - Uses mock_requests_get which is a valid response object
+        - mocks the api response & the database used
+           - api finds one new raindrop
+        - rds processed for real
+        - `tasks_to_create` created for real
+        - 
+        """
+        # Arrange
+        ## 1 - need a mock database
+        ## 2 - need to be able "write" to the new database file
+        ## 3 - mock API response with two new rds
+        ## 4 - monkeypatch the todoist_api call
+                
+        ### a) Make a database out of rd_api_response_one minus TWO rds
+        ### b) Make the API response out of ALL of rd_api_response
+        
+        # MockTodoistTaskCreator.return_value.create_task.return_value = None
+
+              
+        
+        
+        # Act
+        ##actual = main()
+        
+        # Assert
+        assert now_formatted == 1
+        
+    
+    

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -17,12 +17,10 @@ from tests.conftest import mock_requests_get
 # This returns a valid response object
 
 
-
 @pytest.fixture
 def mock_raindrops_data():
     with open("tests/mock_data/cumulative_rd_list.json") as f:
         return json.load(f)
-
 
 @pytest.fixture
 def mock_raindrop_client(mock_raindrops_data, monkeypatch):
@@ -43,7 +41,6 @@ def mock_raindrops_processor(monkeypatch):
         "newly_favourited_raindrops_extractor",
         mock_newly_favourited_raindrops_extractor,
     )
-
 
 @pytest.fixture
 def mock_todoist_creator(monkeypatch):
@@ -191,7 +188,7 @@ class TestMainValidReturns:
 
     @pytest.fixture
     def mock_database_env(self, monkeypatch, mocked_db_data):
-        """A fixture to mock database/metafile attribes in a DatabaseManager object.
+        """A fixture to mock database/metafile attributes in a DatabaseManager object.
         
         For dumb future me: pass this fixture as an argument to any test and 
         all DatabaseManager calls will be mocked to temp files. 
@@ -210,8 +207,7 @@ class TestMainValidReturns:
         of test.
         
         Teardown is performed by the shutil commands. (see notes below).
-            
-        
+       
         Parameters
         ----------
         monkeypatch

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -48,7 +48,7 @@ def mock_todoist_creator(monkeypatch):
         pass
     # monkeypatch.setattr(TodoistTaskCreator, "create_task", mock_create_task)
 
-
+@pytest.skip # IS RUNNING REAL STUFF!!
 class TestStaleTokenFunctionality:
     """
     Class to focus on testing the stale token functionality. Almost all of the remainder
@@ -58,6 +58,7 @@ class TestStaleTokenFunctionality:
     def test_working_test(self):
         assert 1 == 1
 
+    @pytest.skip # this runs the stale token refresher for real!
     def test_test_setup(
         self,
         mock_raindrop_client,
@@ -80,6 +81,7 @@ class TestStaleTokenFunctionality:
         x = main()
         assert x == None
 
+    @pytest.skip # prob fine but need to check 
     def test_invalid_token(
         self,
         mock_raindrop_client,
@@ -94,6 +96,7 @@ class TestStaleTokenFunctionality:
             main()
             mock_refresh_token_runner.assert_called_once()
 
+    @pytest.skip # prob fine but need to check
     def test_valid_token(
         self,
         mock_raindrop_client,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -370,10 +370,18 @@ class TestMainValid:
             assert len(new_favs_found) == 2
 
     def test_task_creation(self, raindrop_object):
-        """
+        """Creates a mock task from a Raindrop using `TodoistTaskCreator.create_task().`
 
-        Takes a Raindrop object to represent a new untracked task.
-
+        `main.py` creates a list of untracked Raindrops called `tasks_to_create`. A for 
+        `TodoistTaskCreator.create_task().` then creates a task for each untracked
+        Raindrop via a for loop in `main.py`.
+        
+        This test uses the mock Raindrop fixture `raindrop_object` as `tasks_to_create`.
+        The test then mocks the Todoist API methods `add_task` and `add_comment` and 
+        patches those methods when instantiating a TodoistTaskCreator object.
+       
+        The test asserts that the mock methods were correctly called with the data from 
+        the mock Raindrop `raindrop_object`.
         """
         # mock raindrop
         untracked_raindrop_object_mock = raindrop_object
@@ -395,7 +403,7 @@ class TestMainValid:
             task_creator = TodoistTaskCreator(untracked_raindrop_object_mock)
             task_creator.create_task()
         
-            ## assertions
+            # assertions
             mock_add_task.assert_called()  # This just checks the method was called
             called_args, called_kwargs = mock_add_task.call_args
             

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -266,7 +266,6 @@ class TestMainValidReturns:
         - `tasks_to_create` created for real
         - 
         """
-        # Arrange
         ## 1 - need a mock database
         ## 2 - need to be able "write" to the new database file
         ## 3 - mock API response with two new rds
@@ -276,15 +275,16 @@ class TestMainValidReturns:
         ### b) Make the API response out of ALL of rd_api_response
         
         # MockTodoistTaskCreator.return_value.create_task.return_value = None
+               
+        # Arrange
+        my_var = 2
 
-              
-        
         
         # Act
         ##actual = main()
         
         # Assert
-        assert now_formatted == 1
+        assert my_var == 1
         
     
     

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import json
 import os
 import shutil
-import tempfile
+from tempfile import TemporaryDirectory
 from typing import Any
 from unittest.mock import patch, Mock
 
@@ -11,9 +11,11 @@ from requests import Response
 
 from main import main
 from raindrop import DatabaseManager, RaindropClient, RaindropsProcessor
+import raindrop
 from todoist import TodoistTaskCreator
 
 from tests.conftest import mock_requests_get
+
 # This returns a valid response object
 
 
@@ -22,14 +24,18 @@ def mock_raindrops_data():
     with open("tests/mock_data/cumulative_rd_list.json") as f:
         return json.load(f)
 
+
 @pytest.fixture
 def mock_raindrop_client(mock_raindrops_data, monkeypatch):
     def mock_get_all_raindrops(self):
         return mock_raindrops_data
+
     def mock_valid_token(self):
         return True
+
     monkeypatch.setattr(RaindropClient, "get_all_raindrops", mock_get_all_raindrops)
     monkeypatch.setattr(RaindropClient, "stale_token", mock_valid_token)
+
 
 @pytest.fixture
 def mock_raindrops_processor(monkeypatch):
@@ -42,10 +48,12 @@ def mock_raindrops_processor(monkeypatch):
         mock_newly_favourited_raindrops_extractor,
     )
 
+
 @pytest.fixture
 def mock_todoist_creator(monkeypatch):
     def mock_create_task(self, task):
         pass
+
     # monkeypatch.setattr(TodoistTaskCreator, "create_task", mock_create_task)
 
 
@@ -54,7 +62,7 @@ class TestStaleTokenFunctionality:
     Class to focus on testing the stale token functionality. Almost all of the remainder
     of the main function is mocked.
     """
-    
+
     def test_working_test(self):
         assert 1 == 1
 
@@ -81,7 +89,7 @@ class TestStaleTokenFunctionality:
         x = main()
         assert x == None
 
-    @pytest.mark.skip(reason="this is prob fine but need to check") 
+    @pytest.mark.skip(reason="this is prob fine but need to check")
     def test_invalid_token(
         self,
         mock_raindrop_client,
@@ -89,14 +97,15 @@ class TestStaleTokenFunctionality:
         mock_todoist_creator,
         caplog,
     ):
-        with patch("raindrop.RaindropOauthHandler.refresh_token_process_runner") as mock_refresh_token_runner, patch(
-            "raindrop.RaindropClient.stale_token",
-            return_value = True
+        with patch(
+            "raindrop.RaindropOauthHandler.refresh_token_process_runner"
+        ) as mock_refresh_token_runner, patch(
+            "raindrop.RaindropClient.stale_token", return_value=True
         ) as mock_valid_token:
             main()
             mock_refresh_token_runner.assert_called_once()
 
-    @pytest.mark.skip(reason="this is also prob fine but need to check") 
+    @pytest.mark.skip(reason="this is also prob fine but need to check")
     def test_valid_token(
         self,
         mock_raindrop_client,
@@ -104,196 +113,228 @@ class TestStaleTokenFunctionality:
         mock_todoist_creator,
         caplog,
     ):
-        with patch("raindrop.RaindropOauthHandler.refresh_token_process_runner") as mock_refresh_token_runner, patch(
-            "raindrop.RaindropClient.stale_token",
-            return_value = False
+        with patch(
+            "raindrop.RaindropOauthHandler.refresh_token_process_runner"
+        ) as mock_refresh_token_runner, patch(
+            "raindrop.RaindropClient.stale_token", return_value=False
         ) as mock_valid_token:
             main()
             mock_refresh_token_runner.assert_not_called()
 
 
-def mock_db_data(self) -> dict[str, any]:
-        """Creates the contents of a database file. 
-        
-        Can be used in memory (as if read from the file) or written to a file and 
-        then read.
-        
-        Source of the data is an extracted API response using a set of real 
-        raindrops created for testing purposes (e.g. BBC News etc).
-        
-        Two items are removed, allowing the same test set to be used to introduce
-        new, untracked raindrops.
-        
-        Returns
-        -------
-        mock_db_data: dict[str, any]
-            A dictionary containing one item, the key "Processed Raindrops" and the
-            value a list of raindrop dictionaries.
-        
-        See Also
-        --------
-        The return value can be used with `create_mock_db_files` to create a tempfile
-        db and metafile data for most realistic use.
-        """
-        mock_db_data = {
-            "Processed Raindrops": [
-                ]
-        }
-        with open("tests/mock_data/rd_api_response_one.json") as f:
-            full_api_response = json.load(f)
-        mock_db_content = full_api_response["items"][:-2]
-        mock_db_data["Processed Raindrops"] = mock_db_content
-        return mock_db_data
-    
-def create_mock_db_files(self, directory: str, filename: str, content: dict[str, list]) -> None:
-    """Creates a mock_db file and accompanying metafile.
-    
-    Parameters
-    ----------
-    directory: str
-        The path to the directory to save the mock_db file.
-    
-    filename: str
-        The name for the file e.g. the db file and metafile (which must be in a 
-        particular format).
-    
-    content: dict[str, list]
-        The content of the database. To be valid this should be in the format of
-        one k,v pair with a key of "Processed Raindrops" and the saved raindrop 
-        content as a list of dictionaries.
-    
-    Note
-    ----
-    This method could be used to create any file - but for ease of future me's
-    understanding, I've described it's specific use in `mock_database_env`.
-    """
-    
-    with open(os.path.join(directory, filename), 'w') as file:
-        file.write(content)
-        #! CHAT GPT says this will error a dict
-        #! prob getting this from my type annotations - which may be wrong! 
-        # json.dump(content, file)
-    return None
-
 @pytest.fixture
-def mock_database_env(self, monkeypatch, mocked_db_data):
-    """A fixture to mock database/metafile attributes in a DatabaseManager object.
-    
-    For dumb future me: pass this fixture as an argument to any test and 
-    all DatabaseManager calls will be mocked to temp files. 
-    
-    The fixture creates temp directories for the db_file and meta_file. (The 
-    programme uses the meta_file to track the latest version of the db json).
-    
-    It uses `mock_db_data` to create the db content then calls 
-    `create_mock_db_files` to write that db content to the files - with the
-    expected file formatting and metadata content.
-    
-    `monkeypatch.setattr` uses pytest's monkeypatch to mock the DatabaseManager
-    attributes. 
-    
-    Yield is used to keep the method open, pending the required teardown at end
-    of test.
-    
-    Teardown is performed by the shutil commands. (see notes below).
-    
-    Parameters
-    ----------
-    monkeypatch
-        pytest generator that does some (as yet not understood) magic stuff.
-    
-    mocked_db_data: dict[str, list]
-        Mock db data of the type created by `mock_db_data` 
-            
-    Notes
-    -----
-    This fixture is better written as: 
-        `with tempfile.TemporaryDirectory() as db_dir...`
-    I used setattr for consistency across tests (see `mock_requests_get`). As part 
-    of an effort to limit myself to a smaller set of testing tools and learn them
-    properly first. (Rather than every test being so different that "Dec-23 you" 
-    found far too little knowledge consolidating.
-    """
-    db_dir = tempfile.mkdtemp()
-    meta_dir = tempfile.mkdtemp()
-    
-    now = datetime.now()
-    now_formatted = now.strftime("%Y%m%d_%H%M")
-    
-    db_file_name = f"001_processed_raindrops_{now_formatted}.json"
-    meta_file_content = f"{meta_dir}/{db_file_name}.json"
-    # Metafile content format:
-    #   database/2391_processed_raindrops_20231231_0729.json
-    
-    self.create_mock_db_files(db_dir, db_file_name, mocked_db_data)
-    self.create_mock_db_files(meta_dir, 'metafile.txt', meta_file_content)
+def mock_db_data() -> dict[str, any]:
+    """Creates the contents of a database file.
 
-    monkeypatch.setattr(DatabaseManager, 'database_directory', db_dir)
-    monkeypatch.setattr(DatabaseManager, 'metafile_directory', meta_dir)
-    monkeypatch.setattr(DatabaseManager, 'metafile_path', os.path.join(meta_dir, 'metafile.txt'))
-        
-    yield
-    
-    shutil.rmtree(db_dir)
-    shutil.rmtree(meta_dir)
+    Can be used in memory (as if read from the file) or written to a file and
+    then read.
+
+    Source of the data is an extracted API response using a set of real
+    raindrops created for testing purposes (e.g. BBC News etc).
+
+    Two items are removed, allowing the same test set to be used to introduce
+    new, untracked raindrops.
+
+    Can be used in conjunction with `mock_requests_get` which currently collects
+    26 raindrops.  This database will hold 23 of those raindrops, leaving 3 "new"
+    raindrops to be actioned.
+
+    Returns
+    -------
+    mock_db_data: dict[str, any]
+        A dictionary containing one item, the key "Processed Raindrops" and the
+        value a list of raindrop dictionaries.
+
+    See Also
+    --------
+    The return value can be used with `create_mock_db_files` to create a tempfile
+    db and metafile data for most realistic use.
+    """
+    mock_db_data = {"Processed Raindrops": []}
+    with open("tests/mock_data/rd_api_response_one.json") as f:
+        full_api_response = json.load(f)
+    mock_db_content = full_api_response["items"][:-2]
+    mock_db_data["Processed Raindrops"] = mock_db_content
+    return mock_db_data
+
+
+# @pytest.fixture
+# def mock_database_environment(monkeypatch, mock_db_data):
+#     """A fixture to mock database/metafile attributes in a DatabaseManager object.
+
+#     For dumb future me: pass this fixture as an argument to any test and
+#     all DatabaseManager calls will be mocked to temp files.
+
+#     The fixture creates temp directories for the db_file and meta_file. (The
+#     programme uses the meta_file to track the latest version of the db json).
+
+#     It uses `mock_db_data` to create the db content then calls
+#     `create_mock_db_files` to write that db content to the files - with the
+#     expected file formatting and metadata content.
+
+#     `monkeypatch.setattr` uses pytest's monkeypatch to mock the DatabaseManager
+#     attributes.
+
+#     Yield is used to keep the method open, pending the required teardown at end
+#     of test.
+
+#     Teardown is performed by the shutil commands. (see notes below).
+
+#     Parameters
+#     ----------
+#     monkeypatch
+#         pytest generator that does some (as yet not understood) magic stuff.
+
+#     mocked_db_data: dict[str, list]
+#         Mock db data of the type created by `mock_db_data`
+
+#     Notes
+#     -----
+#     This fixture is better written as:
+#         `with tempfile.TemporaryDirectory() as db_dir...`
+#     I used setattr for consistency across tests (see `mock_requests_get`). As part
+#     of an effort to limit myself to a smaller set of testing tools and learn them
+#     properly first. (Rather than every test being so different that "Dec-23 you"
+#     found far too little knowledge consolidating.
+#     """
+#     db_dir = tempfile.mkdtemp()
+#     meta_dir = tempfile.mkdtemp()
+#     now = datetime.now().strftime("%Y%m%d_%H%M")
+
+#     db_file_name = f"001_processed_raindrops_{now}.json"
+#     meta_file_content = f"{meta_dir}/{db_file_name}"
+#     # Metafile content format:
+#     #   database/2391_processed_raindrops_20231231_0729.json
+
+#     with open(os.path.join(db_dir, db_file_name), 'w') as f:
+#         json.dump(mock_db_data, f)
+
+#     with open(os.path.join(meta_dir, 'metafile.txt'), 'w') as f:
+#         f.write(meta_file_content)
+
+#     db_manager  = DatabaseManager()
+#     monkeypatch.setattr(db_manager, 'database_directory', db_dir)
+#     monkeypatch.setattr(db_manager, 'metafile_directory', meta_dir)
+#     monkeypatch.setattr(db_manager, 'metafile_path', os.path.join(meta_dir, 'metafile.txt'))
+
+#     yield
+
+#     shutil.rmtree(db_dir)
+#     shutil.rmtree(meta_dir)
 
 
 class TestMainValid:
     """
     Full happy path integration test with the minimum amount of mocking.
-    
-    Includes individual tests for each mock used for traceability and clarity. 
-    
+
+    Includes individual tests for each mock used for traceability and clarity.
+
     DETAILS
     --------
     What does `main.main` do and how is mocking handled?
-    
-    1)  `main.main` confirms the Oauth token is not stale by making an API call using 
+
+    1)  `main.main` confirms the Oauth token is not stale by making an API call using
         data in the .env file.
-    
-    - patched to return Oauth token is valid 
-    
+
+    - patched to return Oauth token is valid
+
     2) Fetches all raindrops from the raindrops api.
-    
+
     #TODO:
     3) Extracts newly favourited raindrops.
     4) Compares them with the database and extracts 'new' favourites.
     5) Writes the new favourites to todoist.
     """
+
     def test_stale_token_patch(self):
-        """Patches stale_token to directly return False.
-        
-        We use `mock_requests_get` in the full int test to include the testing of the
-        `stale_token` functionality.
+        """Patches `stale_token` to directly return False.
+
+        `stale_token` is a `RaindropClient()` method to test if the Oauth2 token is
+        valid or needs refreshing.
+
+        NOTE: This mock approach is not used in the integration test. See
+        `test_stale_token_requests_patch` for the preferred approach.
         """
         rc = RaindropClient()
-        with patch('raindrop.RaindropClient.stale_token', return_value=7): 
+        with patch("raindrop.RaindropClient.stale_token", return_value=7):
             stale_token = rc.stale_token()
         assert stale_token == 7
-    
+
     def test_stale_token_requests_patch(self, mock_requests_get):
-        """Uses `mock_requests_get` to monkeypatch `stale_token` uses the p1 of the
-        dummy data returned by `mock_requests_get`.  
-        
-        `stale_token` only requires the get request not to error - it doesn't even check
-        status_code - but `mock_requests_get` does return valid status_codes if req'd.
-        """    
+        """Monkeypatches `requests.get` to assert `stale_token` is not true.
+
+        For `stale_token` see `test_stale_token_patch`.
+
+        Uses `mock_requests_get` to monkeypatch `stale_token`. P1 of the
+        dummy data is returned by `mock_requests_get`. `stale_token` considers a token
+        valid as long as `requests.get` doesn't raise an error. (It doesn't check
+        status_code - but `mock_requests_get` does return valid status_codes if req'd).
+        """
         rc = RaindropClient()
         stale_token = rc.stale_token()
         assert stale_token == False
-        
+
     def test_get_all_rds(self, mock_requests_get):
-        """Uses `mock_requests_get` to monkeypatch `requests.get`.
-        
-        Only the `.get` itself is mocked. Two valid pages of API response are returned
-        and validated.  `output` is list of 26 raindrops.
+        """Calls `get_all_rds` with a mock valid API response of 26 raindrops .
+
+        `get_all_rds` is the primary RaindropClient() method.
+
+        This test uses `mock_requests_get` to monkeypatch `requests.get`. Only the
+        `.get` itself is mocked. Two valid pages of API response are returned
+        and validated. `output` is list of 26 raindrops.
+
+        `mock_requests_get` can be used directly in the full integration test.
         """
         rc = RaindropClient()
         output = rc.get_all_raindrops()
         assert len(output) == 26
         assert type(output) == list
-        assert output[0]['title'] == "Hacker News"
-    
+        assert output[0]["title"] == "Hacker News"
+
+    def test_newly_favourited_rd_extractor(self, mock_requests_get, mock_db_data, tmp_path):
+        """
+        `newly_favourited_rd_extractor` is the main RaindropsProcessor() method.
+        #TODO: in progress. Working on. See issue for latest.
+        """
+        now = datetime.now().strftime("%Y%m%d_%H%M")
+                
+        # Create mock db
+        db_dir = tmp_path / "database"
+        db_file_name = f"001_processed_raindrops_{now}.json"
+        db_dir.mkdir()
+        with open(os.path.join(db_dir, db_file_name), "w") as f:
+            json.dump(mock_db_data, f)
+
+        # Create mock metafile
+        meta_dir = tmp_path / "metafile"
+        meta_file_content = f"{db_dir}/{db_file_name}"  #e.g. "database/2391_processed_raindrops_20231231_0729.json"
+        meta_dir.mkdir()
+        with open(os.path.join(meta_dir, "metafile.txt"), "w") as f:
+            f.write(meta_file_content)
+
+        with patch.object(
+            DatabaseManager, '__init__', lambda self: self.__dict__.update(
+                {
+            "database_directory": str(db_dir),
+            "metafile_directory": str(meta_dir),
+            "metafile_path": os.path.join(meta_dir, 'metafile.txt')
+                }
+                )
+            ) as mock_init:
+        
+            rc = RaindropClient()
+            # Get mock API response of 26 raindrops
+            output = rc.get_all_raindrops()
+            assert len(output) == 26
+
+            # Instantiate rp with the 26 raindrops
+            rp = RaindropsProcessor(output)
+
+            # Process 26 raindrops against 23 in mock database
+            new_rds_found = rp.newly_favourited_raindrops_extractor()
+
+            assert len(new_rds_found) == 0
+
     # @pytest.mark.skip(message="Not finished yet")
     def test_happy_path(self, mock_requests_get):
         """
@@ -306,4 +347,3 @@ class TestMainValid:
         output = rc.get_all_raindrops()
         assert stale_token == False
         assert len(output) == 26
-   

--- a/tests/mock_data/mock_db.json
+++ b/tests/mock_data/mock_db.json
@@ -7,14 +7,6 @@
             "title": "Hacker News", 
             "notes": "",
             "link": "https://news.ycombinator.com/news"
-        },
-        {
-            "id": 628161679,
-            "created_time": "2023-08-14T09:36:24.867Z",
-            "parsed_time": "2023-06-14T16:10:14.085+00:00",
-            "title": "The Times & The Sunday Times: breaking news & today's latest headlines", 
-            "notes": "",
-            "link": "https://www.thetimes.co.uk/"
         }
     ]
 }

--- a/tests/mock_data/mock_db.json
+++ b/tests/mock_data/mock_db.json
@@ -1,0 +1,20 @@
+{
+    "Processed Raindrops": [
+        {
+            "id": 628161680,
+            "created_time": "2023-08-14T09:36:24.868Z",
+            "parsed_time": "2023-06-14T16:10:14.085+00:00",
+            "title": "Hacker News", 
+            "notes": "",
+            "link": "https://news.ycombinator.com/news"
+        },
+        {
+            "id": 628161679,
+            "created_time": "2023-08-14T09:36:24.867Z",
+            "parsed_time": "2023-06-14T16:10:14.085+00:00",
+            "title": "The Times & The Sunday Times: breaking news & today's latest headlines", 
+            "notes": "",
+            "link": "https://www.thetimes.co.uk/"
+        }
+    ]
+}

--- a/tests/mock_data/rd_api_response_one.json
+++ b/tests/mock_data/rd_api_response_one.json
@@ -38,6 +38,7 @@
       },
       "duplicate": null,
       "broken": false,
+      "important": true,
       "collectionId": 36697540
     },
     {
@@ -75,6 +76,7 @@
         "created": "2023-08-14T09:37:50.337Z"
       },
       "broken": false,
+      "important": true,
       "collectionId": 36697540
     },
     {

--- a/tests/mock_data/rd_api_single_rd.json
+++ b/tests/mock_data/rd_api_single_rd.json
@@ -1,43 +1,37 @@
 {
-  "_id": 621872658,
-  "broken": false,
-  "cache": {
-    "created": "2023-08-06T19:57:10.000Z",
-    "size": 182846,
-    "status": "ready"
-  },
-  "collection": { "$id": 31352328, "$ref": "collections", "oid": 31352328 },
-  "collectionId": 31352328,
-  "cover": "https://opengraph.githubassets.com/e1bbb2f1946ae6b1b3182a2a7e226114ffff058910f8426d1aad736dff6b513d/tadashi-aikawa/shukuchi",
-  "created": "2023-08-06T19:56:44.948Z",
+  "_id": 628161672,
+  "link": "https://www.python.org/",
+  "title": "Welcome to Python.org",
+  "excerpt": "The official home of the Python Programming Language",
+  "note": "",
+  "type": "link",
+  "user": { "$ref": "users", "$id": 645158 },
+  "cover": "https://www.python.org/static/opengraph-icon-200x200.png",
+  "media": [
+    {
+      "type": "image",
+      "link": "https://www.python.org/static/opengraph-icon-200x200.png"
+    }
+  ],
+  "tags": [],
+  "removed": false,
+  "collection": { "$ref": "collections", "$id": 36697540, "oid": 36697540 },
+  "highlights": [],
+  "created": "2023-08-14T09:36:24.856Z",
+  "lastUpdate": "2023-08-14T09:36:24.856Z",
+  "domain": "python.org",
   "creatorRef": {
     "_id": 645158,
     "avatar": "",
-    "email": "",
-    "name": "christopherbillows"
+    "name": "christopherbillows",
+    "email": ""
   },
-  "domain": "github.com",
-  "excerpt": "Shukuchi is an Obsidian plugin that enables you to teleport to links (URL or internal link). - tadashi-aikawa/shukuchi: Shukuchi is an Obsidian plugin that enables you to teleport to links (URL or ...",
-  "highlights": [],
-  "important": false,
-  "lastUpdate": "2023-08-06T19:56:46.806Z",
-  "link": "https://github.com/tadashi-aikawa/shukuchi",
-  "media": [
-    {
-      "link": "https://opengraph.githubassets.com/e1bbb2f1946ae6b1b3182a2a7e226114ffff058910f8426d1aad736dff6b513d/tadashi-aikawa/shukuchi",
-      "type": "image"
-    },
-    {
-      "link": "https://raw.githubusercontent.com/tadashi-aikawa/shukuchi/master/resources/direction-of-possible-teleportation.png",
-      "type": "image"
-    }
-  ],
-  "note": "",
-  "reminder": { "date": null },
-  "removed": false,
-  "sort": 621872658,
-  "tags": [],
-  "title": "tadashi-aikawa/shukuchi: Shukuchi is an Obsidian plugin that enables you to teleport to links (URL or internal link).",
-  "type": "link",
-  "user": { "$id": 645158, "$ref": "users" }
+  "sort": 628161672,
+  "cache": {
+    "status": "ready",
+    "size": 297859,
+    "created": "2023-08-14T09:37:50.337Z"
+  },
+  "broken": false,
+  "collectionId": 36697540
 }

--- a/tests/unit/test_raindrop_class.py
+++ b/tests/unit/test_raindrop_class.py
@@ -2,8 +2,6 @@ from unittest import mock
 import json
 import pytest
 
-from raindrop import Raindrop
-
 
 # @pytest.fixture
 # def raindrop_body():
@@ -25,25 +23,6 @@ def rd_raw_api_response():
         content = json.load(f)
         requests_obj.json = mock.Mock(return_value=content)
     return requests_obj
-   
-
-@pytest.fixture
-def rd_extracted_single_raindrop_dict():
-    """
-    Returns a dictionary representation of a single raindrop. 
-    In actual usage, this structure is typically extracted from a list of 
-    raindrops that have been processed with json.load. For testing purposes, 
-    this fixture loads the content of a single raindrop saved as JSON from a file.
-    """
-    with open('tests/mock_data/rd_api_single_rd.json', "r") as f:
-        content = json.load(f)
-    return content
-
-
-@pytest.fixture
-def raindrop_object(rd_extracted_single_raindrop_dict):
-   return Raindrop(rd_extracted_single_raindrop_dict)
-
 
 class TestInit:
     """

--- a/todoist.py
+++ b/todoist.py
@@ -75,7 +75,7 @@ class TodoistTaskCreator:
             )
 
             self._add_link_as_comment(task.id)
-            logger.info(f"Created task: {task.title}")
+            logger.info(f"Created task: {task.content}")
 
         except Exception as e:
             logger.error(e)

--- a/todoist.py
+++ b/todoist.py
@@ -75,6 +75,7 @@ class TodoistTaskCreator:
             )
 
             self._add_link_as_comment(task.id)
+            logger.info(f"Created task: {task.title}")
 
         except Exception as e:
             logger.error(e)


### PR DESCRIPTION
The database JSON now does now only updates on every run.

It does create a new entire version of the file for each Raindrop/Task.  

This was done because:

- When switching to SQLite in #11 the assumption would be that each "write" will be individual like this.  

- for continued observation of the processing during use.  i.e. I didn't want to overwrite the existing file each time at this stage. 


