### PR TITLE
#53: Allow skip slow tests with `slow` mark.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    slow: mark a test as slow to run

--- a/tests/unit/test_raindrop_client.py
+++ b/tests/unit/test_raindrop_client.py
@@ -191,6 +191,7 @@ class TestMakeApiCall:
             json_data = json_data[key]
         assert json_data == expected_value
 
+    @pytest.mark.slow
     @pytest.mark.parametrize(
         "status_code, exception, match_str, call_count",
         [


### PR DESCRIPTION
Fixes #53 .

## PR Checklist
- [X] ⏫ Has the issue number been added above?
- [X] Do the tests past locally?
